### PR TITLE
Update mix.exs to point to the correct Github repo

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -40,6 +40,6 @@ defmodule Braise.Mixfile do
   defp package do
     [maintainers: ["Patrick Robertson", "Alex Rothenberg"],
      licenses: ["MIT"],
-     links: %{github: "https://github.com/patricksrobertson/secure_random.ex"}]
+     links: %{github: "https://github.com/IoraHealth/braise"}]
   end
 end


### PR DESCRIPTION
Spotted on hex.pm when I tried to check out the source